### PR TITLE
Aa/split atom config pages

### DIFF
--- a/src/routes/interactive-embed/+page.svelte
+++ b/src/routes/interactive-embed/+page.svelte
@@ -6,7 +6,7 @@
 	import Video from './components/Video.svelte';
 	import Audio from './components/Audio.svelte';
 	import Dev from './components/Dev.svelte';
-	import AtomConfigurator from './components/Atom-config.svelte';
+	import CultureLists from './components/Culture-lists.svelte';
 
 	// THEME
 	let isDark = $state(true);
@@ -24,7 +24,7 @@
 	});
 
 	// SIMPLE VIEW
-	const views = ['home', 'colour', 'video', 'audio', 'dev', 'atom-configurator'];
+	const views = ['home', 'colour', 'video', 'audio', 'dev', 'culture-lists'];
 	let view = $state('home');
 	let hydrated = false;
 	function navigate(id) {
@@ -95,9 +95,10 @@
 					<h3>&lt;dev&gt;</h3>
 					<p>Free-form JSON (bring your own keys).</p>
 				</button>
-				<button class="card" onclick={() => navigate('atom-configurator')}>
-					<h3>Atom Configurator</h3>
-					<p>Build configuration containers for interactive atoms.</p>
+				<button class="card" onclick={() => navigate('culture-lists')}>
+					<span class="pill">template</span>
+					<h3>Culture Lists</h3>
+					<p>Manage and display culture-related lists.</p>
 				</button>
 			</div>
 		</section>
@@ -109,8 +110,8 @@
 		<Audio onBack={() => navigate('home')} />
 	{:else if view === 'dev'}
 		<Dev onBack={() => navigate('home')} />
-	{:else if view === 'atom-configurator'}
-		<AtomConfigurator onBack={() => navigate('home')} />
+	{:else if view === 'culture-lists'}
+		<CultureLists onBack={() => navigate('home')} />
 	{/if}
 
 	<footer class="hint">

--- a/src/routes/interactive-embed/+page.svelte
+++ b/src/routes/interactive-embed/+page.svelte
@@ -7,6 +7,7 @@
 	import Audio from './components/Audio.svelte';
 	import Dev from './components/Dev.svelte';
 	import CultureLists from './components/Culture-lists.svelte';
+	import SnapSlides from './components/Snap-slides.svelte';
 
 	// THEME
 	let isDark = $state(true);
@@ -24,7 +25,7 @@
 	});
 
 	// SIMPLE VIEW
-	const views = ['home', 'colour', 'video', 'audio', 'dev', 'culture-lists'];
+	const views = ['home', 'colour', 'video', 'audio', 'dev', 'culture-lists', 'snap-slides'];
 	let view = $state('home');
 	let hydrated = false;
 	function navigate(id) {
@@ -100,6 +101,11 @@
 					<h3>Culture Lists</h3>
 					<p>Manage and display culture-related lists.</p>
 				</button>
+				<button class="card" onclick={() => navigate('snap-slides')}>
+					<span class="pill">template</span>
+					<h3>Snap Slides</h3>
+					<p>Manage and display lists with snap-slides layout.</p>
+				</button>
 			</div>
 		</section>
 	{:else if view === 'colour'}
@@ -112,6 +118,8 @@
 		<Dev onBack={() => navigate('home')} />
 	{:else if view === 'culture-lists'}
 		<CultureLists onBack={() => navigate('home')} />
+	{:else if view === 'snap-slides'}
+		<SnapSlides onBack={() => navigate('home')} />
 	{/if}
 
 	<footer class="hint">

--- a/src/routes/interactive-embed/components/Culture-lists.svelte
+++ b/src/routes/interactive-embed/components/Culture-lists.svelte
@@ -1,0 +1,154 @@
+<script>
+	import { onMount } from 'svelte';
+	import { ATOM_CONFIG__ATOMS, getAtomProps, getAtomUrl } from '../atom-config';
+	import { json } from '@sveltejs/kit';
+	import { escapeForSingleQuotedAttr } from '../utils';
+	import { get } from 'svelte/store';
+
+	// This component allows to build configuration containers for interactive atoms.
+	const { onBack } = $props();
+
+	const atomTypes = ATOM_CONFIG__ATOMS;
+
+	let isPretty = $state(false);
+	let selectedAtomType = $state('');
+	let selectedAtomUrl = $derived(selectedAtomType ? getAtomUrl(selectedAtomType) : '');
+	let copiedMsg = $state('');
+	let errorMsg = $state('');
+	let inputValues = $state([]);
+
+	let selectedAtomProps = $derived.by(() => {
+		return getAtomProps(selectedAtomType);
+	});
+
+	let jsonAttrs = $state('');
+
+	let jsonText = $derived.by(() => {
+		try {
+			// Validate JSON
+			JSON.parse(jsonAttrs);
+			const escaped = escapeForSingleQuotedAttr(jsonAttrs);
+			return `<div class="interactive" data-props='${escaped}'></div>`;
+		} catch (e) {
+			return e.message;
+		}
+	});
+
+	const initInputValues = () => {
+		const arr = [];
+		selectedAtomProps.forEach((prop) => {
+			// Initialize with default values
+			if (prop.type === 'checkbox') {
+				arr.push(prop.value || false);
+			} else {
+				arr.push(prop.value || '');
+			}
+		});
+		inputValues = [...arr];
+	};
+
+	$effect(() => {
+		if (selectedAtomType && selectedAtomProps) {
+			initInputValues();
+		}
+	});
+
+	const setJsonAttrs = () => {
+		if (selectedAtomProps) {
+			const atomProps = $state.snapshot(selectedAtomProps);
+			const obj = {};
+			atomProps.forEach((prop, index) => {
+				obj[prop.name] = inputValues[index];
+			});
+			jsonAttrs = JSON.stringify(obj, null, isPretty ? 2 : 0);
+		}
+	};
+
+	$effect(() => {
+		if (inputValues) {
+			setJsonAttrs();
+		}
+	});
+
+	function resetDev() {
+		selectedAtomType = '';
+		inputValues = [];
+		jsonAttrs = '';
+		isPretty = false;
+		errorMsg = '';
+		copiedMsg = '';
+	}
+</script>
+
+<section class="view active" aria-labelledby="dev-heading">
+	<div class="panel">
+		<div class="title-row">
+			<h2 id="dev-heading">Atom Configurator</h2>
+			<button class="back" onclick={() => onBack()}>← Back</button>
+		</div>
+
+		<form autocomplete="off">
+			<div class="row">
+				<div class="field">
+					<label for="dev-element">Atom type</label>
+					<select
+						id="dev-element"
+						type="select"
+						placeholder="e.g. 'gallery' or 'quiz'"
+						bind:value={selectedAtomType}
+					>
+						{#each atomTypes as atomType}
+							<option value={atomType.id}>{atomType.name}</option>
+						{/each}
+					</select>
+				</div>
+			</div>
+			<div class="row">
+				{#if selectedAtomType && selectedAtomUrl}
+					<p class="hint">
+						The atom url for <strong>{selectedAtomType}</strong> is: <em>{selectedAtomUrl}</em>
+					</p>
+				{/if}
+			</div>
+
+			<div class="row">
+				{#if selectedAtomType && selectedAtomProps}
+					{#each selectedAtomProps as prop, index}
+						<div class="field">
+							{#if prop.type === 'checkbox'}
+								<label class="switch" for={prop.name}>
+									<input id={prop.name} type="checkbox" bind:checked={inputValues[index]} />
+									<span>{prop.description}</span>
+								</label>
+							{/if}
+						</div>
+					{/each}
+				{/if}
+			</div>
+
+			<div class="field">
+				<label class="switch" for="dev-pretty">
+					<input id="dev-pretty" type="checkbox" bind:checked={isPretty} />
+					<span>Pretty-print JSON (for readability only)</span>
+				</label>
+			</div>
+		</form>
+		<br />
+		<div class="out">
+			<div class="actions">
+				<button
+					class="btn"
+					onclick={() => import('../utils').then(m => m.copy(jsonText, (m2)=>copiedMsg=m2))}
+					>Copy to clipboard</button
+				>
+				<button class="btn secondary" onclick={resetDev}>Reset</button>
+			</div>
+
+			<textarea class="snippet" readonly bind:value={jsonText}></textarea>
+			<p class="hint" role="status" aria-live="polite">{copiedMsg}</p>
+			{#if errorMsg}
+				<p class="error" aria-live="assertive">{errorMsg}</p>
+			{/if}
+		</div>
+	</div>
+</section>

--- a/src/routes/interactive-embed/components/Culture-lists.svelte
+++ b/src/routes/interactive-embed/components/Culture-lists.svelte
@@ -1,6 +1,4 @@
 <script>
-	import { onMount } from 'svelte';
-	import { ATOM_CONFIG__ATOMS, getAtomProps, getAtomUrl } from '../atom-config';
 	import { json } from '@sveltejs/kit';
 	import { escapeForSingleQuotedAttr } from '../utils';
 	import { get } from 'svelte/store';
@@ -8,21 +6,30 @@
 	// This component allows to build configuration containers for interactive atoms.
 	const { onBack } = $props();
 
-	const atomTypes = ATOM_CONFIG__ATOMS;
+	let atomProps = $state([
+		{
+			name: 'isEoY',
+			type: 'checkbox',
+			value: false,
+			description: 'Tick box to enable End of Year styling'
+		},
+		{
+			name: 'renderNavBar',
+			type: 'checkbox',
+			value: true,
+			description: 'Tick box to render the navigation bar'
+		}
+	]);
 
 	let isPretty = $state(false);
-	let selectedAtomType = $state('');
-	let selectedAtomUrl = $derived(selectedAtomType ? getAtomUrl(selectedAtomType) : '');
+	let atomName = $state('culture-lists');
+	let atomUrl = $state(
+		'https://content.guardianapis.com/atom/interactive/interactives/2025/08/2025-list-template/default-list'
+	);
 	let copiedMsg = $state('');
 	let errorMsg = $state('');
 	let inputValues = $state([]);
-
-	let selectedAtomProps = $derived.by(() => {
-		return getAtomProps(selectedAtomType);
-	});
-
 	let jsonAttrs = $state('');
-
 	let jsonText = $derived.by(() => {
 		try {
 			// Validate JSON
@@ -36,7 +43,7 @@
 
 	const initInputValues = () => {
 		const arr = [];
-		selectedAtomProps.forEach((prop) => {
+		atomProps.forEach((prop) => {
 			// Initialize with default values
 			if (prop.type === 'checkbox') {
 				arr.push(prop.value || false);
@@ -48,16 +55,16 @@
 	};
 
 	$effect(() => {
-		if (selectedAtomType && selectedAtomProps) {
+		if (atomName && atomProps) {
 			initInputValues();
 		}
 	});
 
 	const setJsonAttrs = () => {
-		if (selectedAtomProps) {
-			const atomProps = $state.snapshot(selectedAtomProps);
+		if (atomProps) {
+			const propsSnap = $state.snapshot(atomProps);
 			const obj = {};
-			atomProps.forEach((prop, index) => {
+			propsSnap.forEach((prop, index) => {
 				obj[prop.name] = inputValues[index];
 			});
 			jsonAttrs = JSON.stringify(obj, null, isPretty ? 2 : 0);
@@ -65,14 +72,14 @@
 	};
 
 	$effect(() => {
-		if (inputValues) {
+		if (inputValues && atomProps) {
 			setJsonAttrs();
 		}
 	});
 
 	function resetDev() {
-		selectedAtomType = '';
 		inputValues = [];
+		initInputValues();
 		jsonAttrs = '';
 		isPretty = false;
 		errorMsg = '';
@@ -83,37 +90,22 @@
 <section class="view active" aria-labelledby="dev-heading">
 	<div class="panel">
 		<div class="title-row">
-			<h2 id="dev-heading">Atom Configurator</h2>
+			<h2 id="dev-heading">Culture Lists</h2>
 			<button class="back" onclick={() => onBack()}>← Back</button>
 		</div>
 
 		<form autocomplete="off">
 			<div class="row">
-				<div class="field">
-					<label for="dev-element">Atom type</label>
-					<select
-						id="dev-element"
-						type="select"
-						placeholder="e.g. 'gallery' or 'quiz'"
-						bind:value={selectedAtomType}
-					>
-						{#each atomTypes as atomType}
-							<option value={atomType.id}>{atomType.name}</option>
-						{/each}
-					</select>
-				</div>
-			</div>
-			<div class="row">
-				{#if selectedAtomType && selectedAtomUrl}
+				{#if atomName && atomUrl}
 					<p class="hint">
-						The atom url for <strong>{selectedAtomType}</strong> is: <em>{selectedAtomUrl}</em>
+						The atom url for <strong>{atomName}</strong> is: <em>{atomUrl}</em>
 					</p>
 				{/if}
 			</div>
 
 			<div class="row">
-				{#if selectedAtomType && selectedAtomProps}
-					{#each selectedAtomProps as prop, index}
+				{#if atomProps}
+					{#each atomProps as prop, index}
 						<div class="field">
 							{#if prop.type === 'checkbox'}
 								<label class="switch" for={prop.name}>

--- a/src/routes/interactive-embed/components/Snap-slides.svelte
+++ b/src/routes/interactive-embed/components/Snap-slides.svelte
@@ -1,0 +1,131 @@
+<script>
+	import { json } from '@sveltejs/kit';
+	import { escapeForSingleQuotedAttr } from '../utils';
+	import { get } from 'svelte/store';
+
+	// This component allows to build configuration containers for interactive atoms.
+	const { onBack } = $props();
+
+	let atomProps = $state([]);
+
+	let isPretty = $state(false);
+	let atomName = $state('snap-slides');
+	let atomUrl = $state('');
+	let copiedMsg = $state('');
+	let errorMsg = $state('');
+	let inputValues = $state([]);
+	let jsonAttrs = $state('');
+	let jsonText = $derived.by(() => {
+		try {
+			// Validate JSON
+			JSON.parse(jsonAttrs);
+			const escaped = escapeForSingleQuotedAttr(jsonAttrs);
+			return `<div class="interactive" data-props='${escaped}'></div>`;
+		} catch (e) {
+			return e.message;
+		}
+	});
+
+	const initInputValues = () => {
+		const arr = [];
+		atomProps.forEach((prop) => {
+			// Initialize with default values
+			if (prop.type === 'checkbox') {
+				arr.push(prop.value || false);
+			} else {
+				arr.push(prop.value || '');
+			}
+		});
+		inputValues = [...arr];
+	};
+
+	$effect(() => {
+		if (atomName && atomProps) {
+			initInputValues();
+		}
+	});
+
+	const setJsonAttrs = () => {
+		if (atomProps) {
+			const propsSnap = $state.snapshot(atomProps);
+			const obj = {};
+			propsSnap.forEach((prop, index) => {
+				obj[prop.name] = inputValues[index];
+			});
+			jsonAttrs = JSON.stringify(obj, null, isPretty ? 2 : 0);
+		}
+	};
+
+	$effect(() => {
+		if (inputValues && atomProps) {
+			setJsonAttrs();
+		}
+	});
+
+	function resetDev() {
+		inputValues = [];
+		initInputValues();
+		jsonAttrs = '';
+		isPretty = false;
+		errorMsg = '';
+		copiedMsg = '';
+	}
+</script>
+
+<section class="view active" aria-labelledby="dev-heading">
+	<div class="panel">
+		<div class="title-row">
+			<h2 id="dev-heading">Snap Slides - Coming soon</h2>
+			<button class="back" onclick={() => onBack()}>← Back</button>
+		</div>
+
+		<!-- <form autocomplete="off">
+			<div class="row">
+				{#if atomName && atomUrl}
+					<p class="hint">
+						The atom url for <strong>{atomName}</strong> is: <em>{atomUrl}</em>
+					</p>
+				{/if}
+			</div>
+
+			<div class="row">
+				{#if atomProps}
+					{#each atomProps as prop, index}
+						<div class="field">
+							{#if prop.type === 'checkbox'}
+								<label class="switch" for={prop.name}>
+									<input id={prop.name} type="checkbox" bind:checked={inputValues[index]} />
+									<span>{prop.description}</span>
+								</label>
+							{/if}
+						</div>
+					{/each}
+				{/if}
+			</div>
+
+			<div class="field">
+				<label class="switch" for="dev-pretty">
+					<input id="dev-pretty" type="checkbox" bind:checked={isPretty} />
+					<span>Pretty-print JSON (for readability only)</span>
+				</label>
+			</div>
+		</form>
+		<br />
+		<div class="out">
+			<div class="actions">
+				<button
+					class="btn"
+					onclick={() => import('../utils').then(m => m.copy(jsonText, (m2)=>copiedMsg=m2))}
+					>Copy to clipboard</button
+				>
+				<button class="btn secondary" onclick={resetDev}>Reset</button>
+			</div>
+
+			<textarea class="snippet" readonly bind:value={jsonText}></textarea>
+			<p class="hint" role="status" aria-live="polite">{copiedMsg}</p>
+			{#if errorMsg}
+				<p class="error" aria-live="assertive">{errorMsg}</p>
+			{/if}
+		</div> -->
+	</div>
+</section>


### PR DESCRIPTION
This PR replaces the Atom Configurator with separate atom-specific config routes. As a start, the Atom configurator route is replaced by 'Culture Lists' and 'Snap Slides'. 
The logic of the Atom configurator has been amended to be atom-specific as well. 
NB: The 'Snap Slides' config page doesn't render a form yet, but it presents a 'coming soon' message.