### PR TITLE
Best Paperbacks config switch for Culture Lists

### DIFF
--- a/src/routes/interactive-embed/atom-config.js
+++ b/src/routes/interactive-embed/atom-config.js
@@ -12,6 +12,12 @@ const ATOM_CONFIG__PROPS = {
 			description: 'Tick box to enable End of Year styling'
 		},
 		{
+			name: 'isBestPaperbacks',
+			type: 'checkbox',
+			value: false,
+			description: 'Tick box to enable Best Paperbacks styling'
+		},
+		{
 			name: 'renderNavBar',
 			type: 'checkbox',
 			value: true,

--- a/src/routes/interactive-embed/components/Culture-lists.svelte
+++ b/src/routes/interactive-embed/components/Culture-lists.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { json } from '@sveltejs/kit';
-	import { escapeForSingleQuotedAttr } from '../utils';
 	import { get } from 'svelte/store';
+	import { escapeForSingleQuotedAttr } from '../utils';
 
 	// This component allows to build configuration containers for interactive atoms.
 	const { onBack } = $props();
@@ -12,6 +12,12 @@
 			type: 'checkbox',
 			value: false,
 			description: 'Tick box to enable End of Year styling'
+		},
+		{
+			name: 'isBestPaperbacks',
+			type: 'checkbox',
+			value: false,
+			description: 'Tick box to enable Best Paperbacks styling'
 		},
 		{
 			name: 'renderNavBar',


### PR DESCRIPTION
This pull request adds support for a new "Best Paperbacks" styling option to the interactive embed configuration. The main changes introduce a new `isBestPaperbacks` checkbox to both the configuration schema and the UI component.

**Configuration updates:**

* Added a new `isBestPaperbacks` checkbox option to the `ATOM_CONFIG__PROPS` array in `atom-config.js`, allowing users to enable or disable Best Paperbacks styling.

**UI updates:**

* Added the `isBestPaperbacks` checkbox option to the configuration form in `Culture-lists.svelte`, enabling the new styling option in the UI.

**Code cleanup:**

* Moved the import of `escapeForSingleQuotedAttr` in `Culture-lists.svelte` for consistency in import order.