### PR TITLE
Revert "Merge pull request #20 from guardian/aa/culture-list-animatio…

### DIFF
--- a/src/routes/interactive-embed/atom-config.js
+++ b/src/routes/interactive-embed/atom-config.js
@@ -22,12 +22,6 @@ const ATOM_CONFIG__PROPS = {
 			type: 'checkbox',
 			value: true,
 			description: 'Tick box to render the navigation bar'
-		},
-		{
-			name: 'animationsOn',
-			type: 'checkbox',
-			value: true,
-			description: 'Tick box to enable animations (works well only with short sections)'
 		}
 	]
 };

--- a/src/routes/interactive-embed/components/Culture-lists.svelte
+++ b/src/routes/interactive-embed/components/Culture-lists.svelte
@@ -24,12 +24,6 @@
 			type: 'checkbox',
 			value: true,
 			description: 'Tick box to render the navigation bar'
-		},
-		{
-			name: 'animationsOn',
-			type: 'checkbox',
-			value: true,
-			description: 'Tick box to enable animations (works well only with short sections)'
 		}
 	]);
 


### PR DESCRIPTION
…n-toggle"

This reverts commit 98f35a9655624a0ea21883796a1002c37c466de6, reversing changes made to bda2d0c2587386ed3746f34d34c28750bae39be5.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
