### PR TITLE
add Rich read embed

### DIFF
--- a/src/routes/interactive-embed/+page.svelte
+++ b/src/routes/interactive-embed/+page.svelte
@@ -8,6 +8,7 @@
 	import Dev from './components/Dev.svelte';
 	import CultureLists from './components/Culture-lists.svelte';
 	import SnapSlides from './components/Snap-slides.svelte';
+	import RichRead from './components/Rich-read.svelte';
 
 	// THEME
 	let isDark = $state(true);
@@ -25,7 +26,7 @@
 	});
 
 	// SIMPLE VIEW
-	const views = ['home', 'colour', 'video', 'audio', 'dev', 'culture-lists', 'snap-slides'];
+	const views = ['home', 'colour', 'video', 'audio', 'dev', 'culture-lists', 'snap-slides', 'rich-read'];
 	let view = $state('home');
 	let hydrated = false;
 	function navigate(id) {
@@ -106,6 +107,11 @@
 					<h3>Snap Slides</h3>
 					<p>Manage and display lists with snap-slides layout.</p>
 				</button>
+				<button class="card" onclick={() => navigate('rich-read')}>
+					<span class="pill">template</span>
+					<h3>Rich Read</h3>
+					<p>Configure a rich chapter read with video media.</p>
+				</button>
 			</div>
 		</section>
 	{:else if view === 'colour'}
@@ -120,6 +126,8 @@
 		<CultureLists onBack={() => navigate('home')} />
 	{:else if view === 'snap-slides'}
 		<SnapSlides onBack={() => navigate('home')} />
+	{:else if view === 'rich-read'}
+		<RichRead onBack={() => navigate('home')} />
 	{/if}
 
 	<footer class="hint">

--- a/src/routes/interactive-embed/atom-config.js
+++ b/src/routes/interactive-embed/atom-config.js
@@ -1,6 +1,7 @@
 export const ATOM_CONFIG__ATOMS = [
 	{ id: 'culture-lists', name: 'Culture Lists' },
-	{ id: 'snap-slides', name: 'Snap Slides' }
+	{ id: 'snap-slides', name: 'Snap Slides' },
+	{ id: 'rich-read', name: 'Rich Read' }
 ];
 
 const ATOM_CONFIG__PROPS = {
@@ -23,12 +24,28 @@ const ATOM_CONFIG__PROPS = {
 			value: true,
 			description: 'Tick box to render the navigation bar'
 		}
+	],
+	'rich-read': [
+		{
+			name: 'mainMediaVideoSrc',
+			type: 'text',
+			value: '',
+			description: 'URL for the main media video source'
+		},
+		{
+			name: 'mainMediaVideoPoster',
+			type: 'text',
+			value: '',
+			description: 'URL for the main media video poster image'
+		}
 	]
 };
 
 const ATOM__URLS = {
 	'culture-lists':
-		'https://content.guardianapis.com/atom/interactive/interactives/2025/08/2025-list-template/default-list'
+		'https://content.guardianapis.com/atom/interactive/interactives/2025/08/2025-list-template/default-list',
+	'rich-read':
+		'https://content.guardianapis.com/atom/interactive/interactives/2026/04/2026-rich-chapter-read/rich-chapter-read'
 };
 
 export const getAtomProps = (atomType) => {

--- a/src/routes/interactive-embed/components/Rich-read.svelte
+++ b/src/routes/interactive-embed/components/Rich-read.svelte
@@ -1,0 +1,149 @@
+<script>
+	import { json } from '@sveltejs/kit';
+	import { get } from 'svelte/store';
+	import { escapeForSingleQuotedAttr } from '../utils';
+
+	// This component allows to build configuration containers for interactive atoms.
+	const { onBack } = $props();
+
+	let atomProps = $state([
+		{
+			name: 'mainMediaVideoSrc',
+			type: 'text',
+			value: '',
+			description: 'URL for the main media video source'
+		},
+		{
+			name: 'mainMediaVideoPoster',
+			type: 'text',
+			value: '',
+			description: 'URL for the main media video poster image'
+		}
+	]);
+
+	let isPretty = $state(false);
+	let atomName = $state('rich-read');
+	let atomUrl = $state(
+		'https://content.guardianapis.com/atom/interactive/interactives/2026/04/2026-rich-chapter-read/rich-chapter-read'
+	);
+	let copiedMsg = $state('');
+	let errorMsg = $state('');
+	let inputValues = $state([]);
+	let jsonAttrs = $state('');
+	let jsonText = $derived.by(() => {
+		try {
+			// Validate JSON
+			JSON.parse(jsonAttrs);
+			const escaped = escapeForSingleQuotedAttr(jsonAttrs);
+			return `<div class="interactive" data-props='${escaped}'></div>`;
+		} catch (e) {
+			return e.message;
+		}
+	});
+
+	const initInputValues = () => {
+		const arr = [];
+		atomProps.forEach((prop) => {
+			// Initialize with default values
+			if (prop.type === 'checkbox') {
+				arr.push(prop.value || false);
+			} else {
+				arr.push(prop.value || '');
+			}
+		});
+		inputValues = [...arr];
+	};
+
+	$effect(() => {
+		if (atomName && atomProps) {
+			initInputValues();
+		}
+	});
+
+	const setJsonAttrs = () => {
+		if (atomProps) {
+			const propsSnap = $state.snapshot(atomProps);
+			const obj = {};
+			propsSnap.forEach((prop, index) => {
+				obj[prop.name] = inputValues[index];
+			});
+			jsonAttrs = JSON.stringify(obj, null, isPretty ? 2 : 0);
+		}
+	};
+
+	$effect(() => {
+		if (inputValues && atomProps) {
+			setJsonAttrs();
+		}
+	});
+
+	function resetDev() {
+		inputValues = [];
+		initInputValues();
+		jsonAttrs = '';
+		isPretty = false;
+		errorMsg = '';
+		copiedMsg = '';
+	}
+</script>
+
+<section class="view active" aria-labelledby="dev-heading">
+	<div class="panel">
+		<div class="title-row">
+			<h2 id="dev-heading">Rich Read</h2>
+			<button class="back" onclick={() => onBack()}>← Back</button>
+		</div>
+
+		<form autocomplete="off">
+			<div class="row">
+				{#if atomName && atomUrl}
+					<p class="hint">
+						The atom url for <strong>{atomName}</strong> is: <em>{atomUrl}</em>
+					</p>
+				{/if}
+			</div>
+
+			<div class="row">
+				{#if atomProps}
+					{#each atomProps as prop, index}
+						<div class="field">
+							{#if prop.type === 'checkbox'}
+								<label class="switch" for={prop.name}>
+									<input id={prop.name} type="checkbox" bind:checked={inputValues[index]} />
+									<span>{prop.description}</span>
+								</label>
+							{:else if prop.type === 'text'}
+								<label for={prop.name}>{prop.description}</label>
+								<input id={prop.name} type="text" bind:value={inputValues[index]} placeholder="https://" />
+							{/if}
+						</div>
+					{/each}
+				{/if}
+			</div>
+
+			<div class="field">
+				<label class="switch" for="dev-pretty">
+					<input id="dev-pretty" type="checkbox" bind:checked={isPretty} />
+					<span>Pretty-print JSON (for readability only)</span>
+				</label>
+			</div>
+		</form>
+		<br />
+		<div class="out">
+			<div class="actions">
+				<button
+					class="btn"
+					onclick={() => import('../utils').then(m => m.copy(jsonText, (m2)=>copiedMsg=m2))}
+					>Copy to clipboard</button
+				>
+				<button class="btn secondary" onclick={resetDev}>Reset</button>
+			</div>
+
+			<textarea class="snippet" readonly bind:value={jsonText}></textarea>
+			<p class="hint" role="status" aria-live="polite">{copiedMsg}</p>
+			{#if errorMsg}
+				<p class="error" aria-live="assertive">{errorMsg}</p>
+			{/if}
+		</div>
+	</div>
+</section>


### PR DESCRIPTION
This PR introduces the embed builder page for Rich read. 

It allows to set two properties: 
- mainMediaVideoSrc
- mainMediaVideoPoster

These are the sources for custom video and poster. The custom video is injected only if there is no video in the main media and if an embed config is found
This feature has been implemented as temporary fix to low resolution cinemagraphs and loops being served by the CDN. As per a conversation had with the Video team, this will potentially change in the future and the CDN will serve better quality videos.